### PR TITLE
Proposing change to docu of startTime

### DIFF
--- a/src/Signal/Time.elm
+++ b/src/Signal/Time.elm
@@ -87,7 +87,7 @@ settledAfter delay sig =
   let trailing = since delay sig |> Discrete.whenChangeTo False
   in  Signal.sampleOn trailing sig
 
-{-| The approximate timestamp of the start of the program.
+{-| The timestamp of the start of the program.
 -}
 startTime : Signal Time
 startTime = Signal.constant () |> timestamps


### PR DESCRIPTION
I'd think no need to say "approximate" there anymore. With the merging of commit https://github.com/elm-lang/core/commit/36962ec5203f5f092033f847eeb05d262a25baf7, the value carried by `startTime` will be exactly the one set in line https://github.com/elm-lang/core/blob/36962ec5203f5f092033f847eeb05d262a25baf7/src/Native/Runtime.js#L37. That happens exactly once, at program start, and the value will be identical to the one seen in the initial value of every `timestamp`ed signal in the program. So it is really the `Time` value with respect to which all other timing information in the program is relative.
