### PR TITLE
 Added an `andMap`, similar to `Task.andMap`

### DIFF
--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -79,7 +79,7 @@ provides a more attractive way to combine several signals together into a
 
     userSignal : Signal User
     userSignal = user
-        `map` nameSignal
+        `Signal.map` nameSignal
         `andMap` ageSignal
         `andMap` numberOfPostsSignal
 -}

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -71,7 +71,7 @@ infixl 4 ~>
 provides a more attractive way to combine several signals together into a
  data type than `map2`, `map3`, etc.
 
-Equivalent to [Signal's ~ operator](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Signal#~).
+Equivalent to [Signal's ~ operator](http://package.elm-lang.org/packages/elm-lang/core/latest/Signal#~).
 
     type alias User =
         { name : String

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -1,5 +1,6 @@
 module Signal.Extra
   ( (~>)
+  , andMap
   , zip
   , zip3
   , zip4
@@ -66,8 +67,23 @@ two!
 
 infixl 4 ~>
 
+{-| Apply a Signal of functions to another signal. Like `Task.andMap`, this
+provides a more attractive way to combine several signals together into a
+ data type than `map2`, `map3`, etc.
 
-{-| Zip two signals into a signal of pairs. 
+    type alias User = { name : String, age : Int, numberOfPosts : Int }
+
+    userSignal : Signal User
+    userSignal = user
+        `map` nameSignal
+        `andMap` ageSignal
+        `andMap` numberOfPostsSignal
+-}
+andMap : Signal (a -> b) -> Signal a -> Signal b
+andMap fnSignal = map2 (\fn i -> fn i) fnSignal
+
+
+{-| Zip two signals into a signal of pairs.
 
     zip Mouse.x Mouse.y == Mouse.position
 -}

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -85,7 +85,7 @@ provides a more attractive way to combine several signals together into a
 -}
 andMap : Signal (a -> b) -> Signal a -> Signal b
 andMap =
-  map2 (\fn i -> fn i)
+  (~)
 
 
 {-| Zip two signals into a signal of pairs.

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -30,16 +30,13 @@ module Signal.Extra
   , withPassive
   ) where
 {-| Utility functions that aren't in the `Signal` module from
-`elm-lang/core`. 
-
-# Flipped fancy map
-@docs (~>)
+`elm-lang/core`.
 
 # Mapping
-@docs andMap
+@docs (~>), andMap
 
 # Zipping and unzipping
-For those too lazy to write a record or union type.  
+For those too lazy to write a record or union type.
 @docs zip, zip3, zip4, unzip, unzip3, unzip4
 
 # Stateful

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -71,7 +71,11 @@ infixl 4 ~>
 provides a more attractive way to combine several signals together into a
  data type than `map2`, `map3`, etc.
 
-    type alias User = { name : String, age : Int, numberOfPosts : Int }
+    type alias User =
+        { name : String
+        , age : Int
+        , numberOfPosts : Int
+        }
 
     userSignal : Signal User
     userSignal = user
@@ -80,7 +84,8 @@ provides a more attractive way to combine several signals together into a
         `andMap` numberOfPostsSignal
 -}
 andMap : Signal (a -> b) -> Signal a -> Signal b
-andMap fnSignal = map2 (\fn i -> fn i) fnSignal
+andMap =
+  map2 (\fn i -> fn i)
 
 
 {-| Zip two signals into a signal of pairs.

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -71,6 +71,8 @@ infixl 4 ~>
 provides a more attractive way to combine several signals together into a
  data type than `map2`, `map3`, etc.
 
+Equivalent to [Signal's ~ operator](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Signal#~).
+
     type alias User =
         { name : String
         , age : Int

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -68,8 +68,8 @@ two!
 infixl 4 ~>
 
 {-| Apply a Signal of functions to another signal. Like `Task.andMap`, this
-provides a more attractive way to combine several signals together into a
- data type than `map2`, `map3`, etc.
+provides a way to combine several signals together into a data type that's
+easier to extend than `map2`, `map3`, etc.
 
 Equivalent to [Signal's ~ operator](http://package.elm-lang.org/packages/elm-lang/core/latest/Signal#~).
 

--- a/src/Signal/Extra.elm
+++ b/src/Signal/Extra.elm
@@ -35,6 +35,9 @@ module Signal.Extra
 # Flipped fancy map
 @docs (~>)
 
+# Mapping
+@docs andMap
+
 # Zipping and unzipping
 For those too lazy to write a record or union type.  
 @docs zip, zip3, zip4, unzip, unzip3, unzip4

--- a/test/Signal/ExtraTest.elm
+++ b/test/Signal/ExtraTest.elm
@@ -175,8 +175,8 @@ andMapAppliesSignalFunctionToSignal =
 signal15 = mailbox ((+) 10)
 signal16 = mailbox 0
 
-andMapAppliesFnIfItUpdates : Task x Test
-andMapAppliesFnIfItUpdates =
+andMapAppliesFunctionIfItUpdates : Task x Test
+andMapAppliesFunctionIfItUpdates =
   let
       signal =
           signal15.signal
@@ -191,8 +191,8 @@ andMapAppliesFnIfItUpdates =
 signal17 = mailbox ((+) 10)
 signal18 = mailbox 0
 
-andMapAppliesFnIfValueSignalUpdates : Task x Test
-andMapAppliesFnIfValueSignalUpdates =
+andMapAppliesFunctionIfValueSignalUpdates : Task x Test
+andMapAppliesFunctionIfValueSignalUpdates =
   let
       signal =
           signal17.signal
@@ -214,7 +214,7 @@ tests =
         , complicatedMappingFiresCorrectly
         , complicatedMappingActuallySamples
         , andMapAppliesSignalFunctionToSignal
-        , andMapAppliesFnIfItUpdates
-        , andMapAppliesFnIfValueSignalUpdates
+        , andMapAppliesFunctionIfItUpdates
+        , andMapAppliesFunctionIfValueSignalUpdates
         ]
     >>> suite "Signal.Extra tests"

--- a/test/Signal/ExtraTest.elm
+++ b/test/Signal/ExtraTest.elm
@@ -149,6 +149,7 @@ complicatedMappingActuallySamples =
         >>- sample signal
         >>> assertEqual [29, 28, 27, 26] >> test "passiveMap2 actually samples"
 
+
 type alias User =
     { name : String
     , age : Int
@@ -170,6 +171,40 @@ andMapAppliesSignalFunctionToSignal =
         >>> assertEqual { name = "Bobby", age = 5 }
         >> test "andMap applies fn in first signal to result of second signal"
 
+
+signal15 = mailbox ((+) 10)
+signal16 = mailbox 0
+
+andMapAppliesFnIfItUpdates : Task x Test
+andMapAppliesFnIfItUpdates =
+  let
+      signal =
+          signal15.signal
+          `andMap` signal16.signal
+  in
+    send signal15.address ((+) 20)
+    >>- sample signal
+    >>> assertEqual 20
+    >> test "andMap applies fn in first signal whenever it changes"
+
+
+signal17 = mailbox ((+) 10)
+signal18 = mailbox 0
+
+andMapAppliesFnIfValueSignalUpdates : Task x Test
+andMapAppliesFnIfValueSignalUpdates =
+  let
+      signal =
+          signal17.signal
+          `andMap` signal18.signal
+  in
+    send signal18.address 10
+    >>- sample signal
+    >>> assertEqual 20
+    >> test "andMap applies fn in first signal to the value of the second when it changes"
+
+
+
 tests : Task x Test
 tests =
     sequence
@@ -179,5 +214,7 @@ tests =
         , complicatedMappingFiresCorrectly
         , complicatedMappingActuallySamples
         , andMapAppliesSignalFunctionToSignal
+        , andMapAppliesFnIfItUpdates
+        , andMapAppliesFnIfValueSignalUpdates
         ]
     >>> suite "Signal.Extra tests"

--- a/test/Signal/ExtraTest.elm
+++ b/test/Signal/ExtraTest.elm
@@ -2,7 +2,7 @@ module Signal.ExtraTest where
 
 import Signal exposing (Mailbox, mailbox, send, foldp, sampleOn, (~), (<~))
 import Task exposing (Task, sequence, andThen)
-import Signal.Extra exposing (passiveMap2, withPassive, mapMany)
+import Signal.Extra exposing (passiveMap2, withPassive, mapMany, andMap)
 import ElmTest.Test exposing (..)
 import ElmTest.Assertion exposing (..)
 import Native.ApanatshkaSignalExtra
@@ -149,6 +149,26 @@ complicatedMappingActuallySamples =
         >>- sample signal
         >>> assertEqual [29, 28, 27, 26] >> test "passiveMap2 actually samples"
 
+type alias User =
+    { name : String
+    , age : Int
+    }
+
+signal13 = mailbox ""
+signal14 = mailbox 0
+
+andMapAppliesSignalFunctionToSignal : Task x Test
+andMapAppliesSignalFunctionToSignal =
+    let
+        signal = User
+            `Signal.map` signal13.signal
+            `andMap` signal14.signal
+    in
+        send signal13.address "Bobby"
+        >>- send signal14.address 5
+        >>- sample signal
+        >>> assertEqual { name = "Bobby", age = 5 }
+        >> test "andMap applies fn in first signal to result of second signal"
 
 tests : Task x Test
 tests =
@@ -158,5 +178,6 @@ tests =
         , passiveMap2ActuallySamples
         , complicatedMappingFiresCorrectly
         , complicatedMappingActuallySamples
+        , andMapAppliesSignalFunctionToSignal
         ]
     >>> suite "Signal.Extra tests"


### PR DESCRIPTION
I really enjoy using `Task.andMap` and `Task.map` to gather together tasks into a function, and was a little disappointed you couldn't do it for a Signal.  

Do you think this is a decent addition to the library? :)
