### PR TITLE
Update for changes in Elm 0.16-alpha.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
         "Signal.Fun"
     ],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "2.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }

--- a/src/Signal/Discrete.elm
+++ b/src/Signal/Discrete.elm
@@ -14,7 +14,7 @@ value, but only when it updates. A prime example is `Mouse.clicks`.
 @docs folde
 -}
 
-import Signal exposing ((<~), (~), Signal)
+import Signal exposing (Signal)
 
 {-| At some point in the future Elm will probably support something like
 this:

--- a/src/Signal/Fun.elm
+++ b/src/Signal/Fun.elm
@@ -13,7 +13,7 @@ careful.
 @docs scan, premap, postmap, bimap
 -}
 
-import Signal exposing (Signal, (<~), (~))
+import Signal exposing (Signal)
 
 {-| Just a shorthand for signals of functions
 -}

--- a/src/Signal/Time.elm
+++ b/src/Signal/Time.elm
@@ -22,8 +22,8 @@ Some functions from the `Time` module that fit in.
 @docs Time, since, delay, timestamp
 -}
 
-import Signal exposing (Signal, (<~), (~))
-import Signal.Extra exposing ((~>))
+import Signal exposing (Signal)
+import Signal.Extra exposing ((~>), (~), (<~))
 import Signal.Discrete as Discrete
 import Time
 

--- a/test/Signal/ExtraTest.elm
+++ b/test/Signal/ExtraTest.elm
@@ -1,8 +1,8 @@
 module Signal.ExtraTest where
 
-import Signal exposing (Mailbox, mailbox, send, foldp, sampleOn, (~), (<~))
+import Signal exposing (Mailbox, mailbox, send, foldp, sampleOn)
 import Task exposing (Task, sequence, andThen)
-import Signal.Extra exposing (passiveMap2, withPassive, mapMany, andMap, deltas)
+import Signal.Extra exposing (passiveMap2, withPassive, mapMany, andMap, deltas, (~), (<~))
 import ElmTest.Test exposing (..)
 import ElmTest.Assertion exposing (..)
 import Native.ApanatshkaSignalExtra

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -5,14 +5,14 @@
     "license": "MIT",
     "source-directories": [
         ".",
-        "../src"
+        "../src",
+        "vendor/elm-test"
     ],
     "exposed-modules": [
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "deadfoxygrandpa/Elm-Test": "1.0.4 <= v < 2.0.0"
+        "elm-lang/core": "2.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }

--- a/test/vendor/elm-test/ElmTest/Assertion.elm
+++ b/test/vendor/elm-test/ElmTest/Assertion.elm
@@ -1,0 +1,38 @@
+module ElmTest.Assertion 
+    ( Assertion(..), assertionList, assertT, assert, assertEqual, assertNotEqual   
+    ) where
+
+{-| The basic component of a test case, an assertion.
+
+# Assert
+@docs Assertion, assertionList, assertT, assert, assertEqual, assertNotEqual
+-}    
+
+import List
+
+{-| An assertion. -}
+type Assertion = AssertTrue     (() -> Bool)
+               | AssertFalse    (() -> Bool)
+               | AssertEqual    (() -> Bool) String String
+               | AssertNotEqual (() -> Bool) String String
+
+{-| Basic function to create an Assert True assertion. Delays execution until tests are run. -}
+assertT : (() -> Bool) -> Assertion
+assertT = AssertTrue
+
+{-| Basic function to create an Assert True assertion. Delays execution until tests are run. -}          
+assert : Bool -> Assertion
+assert b = AssertTrue (\_ -> b)
+
+{-| Basic function to create an Assert Equals assertion, the expected value goes on the left. -}
+assertEqual : a -> a -> Assertion
+assertEqual a b = AssertEqual (\_ -> a == b) (toString a) (toString b)
+
+{-| Given a list of values and another list of expected values,
+generate a list of Assert Equal assertions. -}
+assertionList : List a -> List a -> List Assertion
+assertionList xs ys = List.map2 assertEqual xs ys
+
+{-| Basic function to create an Assert Not Equals assertion. -}
+assertNotEqual : a -> a -> Assertion
+assertNotEqual a b = AssertNotEqual (\_ -> a /= b) (toString a) (toString b)

--- a/test/vendor/elm-test/ElmTest/Run.elm
+++ b/test/vendor/elm-test/ElmTest/Run.elm
@@ -1,0 +1,160 @@
+module ElmTest.Run
+    ( Result(..), run, pass, fail
+    , failedTests, passedTests, failedSuites, passedSuites
+    ) where
+
+{-| Basic utilities for running tests and customizing the output. If you don't care about customizing
+the output, instead look at the `runDisplay` series in ElmTest.Runner
+
+# Run
+@docs Result, run, pass, fail
+
+# Undocumented
+@docs failedTests, passedTests, failedSuites, passedSuites
+-}
+
+import ElmTest.Assertion exposing (..)
+import ElmTest.Test exposing (..)
+import List
+
+
+type alias Summary =
+    { results  : List Result
+    , passes   : List Result
+    , failures : List Result
+    }
+
+
+{-| Test result -}
+type Result
+    = Pass String
+    | Fail String String
+    | Report String Summary
+
+
+{-| Run a test and get a Result -}
+run : Test -> Result
+run test =
+    case test of
+        TestCase name assertion ->
+            let
+                runAssertion t m =
+                    if t ()
+                        then Pass name
+                        else Fail name m
+            in 
+                case assertion of
+                    AssertEqual t a b ->
+                        runAssertion t <|
+                            "Expected: " ++ a ++ "; got: " ++ b
+                    
+                    AssertNotEqual t a b ->
+                        runAssertion t <|
+                            a ++ " equals " ++ b
+                    
+                    AssertTrue  t ->
+                        runAssertion t <|
+                            "not True"
+                    
+                    AssertFalse t ->
+                        runAssertion t <| "not False"
+        
+        Suite name tests ->
+            let
+                results =
+                    List.map run tests
+                    
+                (passes, fails) =
+                    List.partition pass results
+
+            in
+                Report name 
+                    { results  = results
+                    , passes   = passes
+                    , failures = fails
+                    }
+
+
+{-| Transform a Result into a Bool. True if the result represents a pass, otherwise False -}
+pass : Result -> Bool
+pass m = 
+    case m of
+        Pass _ ->
+            True
+        
+        Fail _ _ ->
+            False
+        
+        Report _ r ->
+            if (List.length (.failures r) > 0)
+                then False
+                else True
+
+
+{-| Transform a Result into a Bool. True if the result represents a fail, otherwise False -}
+fail : Result -> Bool
+fail = not << pass
+
+
+{-| Undocumented. -}
+passedTests : Result -> Int
+passedTests result =
+    case result of
+        Pass _ ->
+            1
+
+        Fail _ _ ->
+            0
+
+        Report n r ->
+            List.sum << List.map passedTests <| r.results
+
+
+{-| Undocumented. -}
+failedTests : Result -> Int
+failedTests result =
+    case result of
+        Pass _ ->
+            0
+
+        Fail _ _ ->
+            1
+            
+        Report n r ->
+            List.sum << List.map failedTests <| r.results
+
+
+{-| Undocumented. -}
+passedSuites : Result -> Int
+passedSuites result =
+    case result of
+        Report n r ->
+            let 
+                passed =
+                    if List.length r.failures == 0
+                        then 1
+                        else 0
+            
+            in
+                passed + (List.sum << List.map passedSuites <| r.results)
+        
+        _ ->
+            0
+
+
+{-| Undocumented. -}
+failedSuites : Result -> Int
+failedSuites result =
+    case result of
+        Report n r ->
+            let
+                failed =
+                    if List.length r.failures > 0
+                        then 1
+                        else 0
+
+            in
+                failed + (List.sum << List.map failedSuites <| r.results)
+                        
+        _ ->
+            0

--- a/test/vendor/elm-test/ElmTest/Runner/Console.elm
+++ b/test/vendor/elm-test/ElmTest/Runner/Console.elm
@@ -1,0 +1,38 @@
+module ElmTest.Runner.Console (runDisplay) where
+
+{-| Run a test suite as a command-line script.
+
+# Run
+@docs runDisplay
+
+-}
+
+import List
+import String
+
+import Console exposing (..)
+
+import ElmTest.Test exposing (..)
+import ElmTest.Run as Run
+import ElmTest.Runner.String as String
+
+{-| Run a list of tests in the IO type from [Max New's Elm IO library](https://github.com/maxsnew/IO/).
+Requires this library to work. Results are printed to console once all tests have completed. Exits with
+exit code 0 if all tests pass, or with code 1 if any tests fail.
+-}
+runDisplay : Test -> IO ()
+runDisplay tests =
+    case String.run tests of
+        (summary, allPassed) :: results ->
+            let 
+                out =
+                    summary ++ "\n\n" ++ (String.concat << List.intersperse "\n" << List.map fst <| results)
+            
+            in
+                putStrLn out >>>
+                    case Run.pass allPassed of
+                        True  -> exit 0
+                        False -> exit 1
+
+        _ ->
+            exit 1

--- a/test/vendor/elm-test/ElmTest/Runner/Element.elm
+++ b/test/vendor/elm-test/ElmTest/Runner/Element.elm
@@ -1,0 +1,72 @@
+module ElmTest.Runner.Element (runDisplay) where
+
+{-| Run a test suite and display it as an Element
+
+# Run
+@docs runDisplay
+
+-}
+
+import Color exposing (..)
+import Graphics.Element exposing (..)
+import List exposing ((::))
+import List
+import String
+import Text
+
+import ElmTest.Run as Run
+import ElmTest.Test exposing (..)
+import ElmTest.Runner.String as String
+
+plainText : String -> Element
+plainText s = leftAligned (Text.fromString s)
+
+-- Given a result, render it in plainText and return a pass/fail color
+pretty : (String, Run.Result) -> Element
+pretty (s, result) =
+    let w = indent s * 10
+        w' = 5
+    in  case result of
+            Run.Pass _   -> color green <| flow right [spacer w 1, plainText s, spacer w' 1]
+            Run.Fail _ _ -> color red <| flow right [spacer w 1, plainText s, spacer w' 1]
+            Run.Report _ _ -> let c = if Run.failedTests result > 0 then red else green
+                              in  color c <| flow right [spacer w 1, leftAligned << Text.bold << Text.fromString <| s, spacer w' 1]
+indent : String -> Int
+indent s = let trimmed = String.trimLeft s
+           in  String.length s - String.length trimmed
+
+maxOrZero : List Int -> Int
+maxOrZero l =
+    List.foldl max 0 l
+
+{-| Runs a list of tests and renders the results as an Element -}
+runDisplay : Test -> Element
+runDisplay tests =
+    case String.run tests of
+        (summary, allPassed) :: results ->
+            let
+                results' =
+                    List.map pretty results
+                
+                maxWidth =
+                    maxOrZero << List.map widthOf <| results'
+                
+                maxHeight =
+                    maxOrZero << List.map heightOf <| results'
+                
+                elements =
+                    if results == [("", allPassed)]
+                        then
+                            []
+                        
+                        else
+                            List.map 
+                                (color black << container (maxWidth + 2) (maxHeight + 2) midLeft << width maxWidth)
+                                results'
+                                
+            in
+                flow down <|
+                    plainText summary :: spacer 1 10 :: elements
+
+        _ ->
+            flow down []

--- a/test/vendor/elm-test/ElmTest/Runner/String.elm
+++ b/test/vendor/elm-test/ElmTest/Runner/String.elm
@@ -1,0 +1,81 @@
+module ElmTest.Runner.String (runDisplay, run) where
+
+{-| Run a test suite and display it as a string.
+
+# Run
+@docs runDisplay, run
+
+-}
+
+import List exposing ((::))
+import List
+import String
+
+import ElmTest.Run as Run
+import ElmTest.Test exposing (..)
+
+-- | Some pretty printing stuff. Should be factored into a pretty printing library.
+vcat : List String -> String
+vcat = String.concat << List.intersperse "\n"
+
+replicate : Int -> Char -> String
+replicate n c = let go n = if n <= 0
+                           then []
+                           else c :: go (n - 1)
+                in String.fromList << go <| n
+
+indent : Int -> String -> String
+indent n = let indents = replicate n ' '
+           in vcat << List.map (String.append indents) << String.lines
+
+pretty : Int -> Run.Result -> List (String, Run.Result)
+pretty n result =
+    let passed = Run.pass result
+    in  case result of
+            Run.Pass name     -> [(indent n <| name ++ ": passed.", result)]
+            Run.Fail name msg -> [(indent n <| name ++ ": FAILED. " ++ msg, result)]
+            Run.Report name r -> let msg = "Test Suite: " ++ name ++ ": "
+                                        ++ if passed then "all tests passed" else "FAILED"
+                                     allPassed = Run.failedTests result == 0
+                                     subResults = if allPassed
+                                                  then []
+                                                  else List.concatMap (pretty (n + 2)) r.results
+                                 in  (indent n msg, result) :: subResults
+
+
+{-| Undocumented. -}
+run : Test -> List (String, Run.Result)
+run t =
+    let result = Run.run t
+        tests = case t of
+                    TestCase n a -> [TestCase n a]
+                    Suite n ts -> ts
+        passedTests'  = Run.passedTests result
+        passedSuites' = Run.passedSuites result
+        failedTests'  = Run.failedTests result
+        failedSuites' = Run.failedSuites result
+        summary = vcat << List.map (indent 2) <| [
+                    toString (numberOfSuites t) ++ " suites run, containing " ++ toString (numberOfTests t) ++ " tests"
+                  , if failedTests' == 0
+                    then "All tests passed"
+                    else toString passedSuites' ++ " suites and " ++ toString passedTests' ++ " tests passed"
+                  , if failedTests' == 0
+                    then ""
+                    else toString failedSuites' ++ " suites and " ++ toString failedTests' ++ " tests failed"
+                  ]
+        --- TODO: implement results printing
+        allPassed   = if failedTests' == 0 then Run.Pass "" else Run.Fail "" ""
+        results' = case allPassed of
+                      Run.Pass _ -> [("", allPassed)]
+                      _          -> pretty 0 result
+    in (summary, allPassed) :: results'
+
+{-| Runs a test or test suite. Returns the report as a String -}
+runDisplay : Test -> String
+runDisplay t =
+    case run t of
+        (summary, _) :: results ->
+            vcat <| (summary ++ "\n") :: List.map fst results
+
+        _ ->
+            ""

--- a/test/vendor/elm-test/ElmTest/Test.elm
+++ b/test/vendor/elm-test/ElmTest/Test.elm
@@ -1,0 +1,64 @@
+module ElmTest.Test 
+    ( Test(..), test, equals, defaultTest, suite
+    , numberOfTests, numberOfSuites
+    ) where
+
+{-| The units of a test suite, named tests.
+
+# Test
+@docs Test, test, equals, defaultTest, suite
+
+# Undocumented
+@docs numberOfTests, numberOfSuites
+
+-}
+
+import ElmTest.Assertion exposing (..)
+import List
+
+
+{-| A test case or a suite. -}
+type Test = TestCase String Assertion | Suite String (List Test)
+
+nameOf : Test -> String
+nameOf test = case test of
+                TestCase n _ -> n
+                Suite    n _ -> n
+
+
+{-| -}
+numberOfTests : Test -> Int
+numberOfTests test = case test of
+                        TestCase _ _  -> 1
+                        Suite    _ ts -> List.sum << List.map numberOfTests <| ts
+
+
+{-| -}
+numberOfSuites : Test -> Int
+numberOfSuites test = case test of
+                        TestCase _ _  -> 0
+                        Suite    _ ts -> 1 + (List.sum << List.map numberOfSuites <| ts)
+
+{-| Convenience function for quickly constructing Assert Equals tests. -}
+equals : a -> a -> Test
+equals a b = defaultTest <| assertEqual a b
+
+{-| Basic function to create a Test Case -}
+test : String -> Assertion -> Test
+test name a = TestCase name a
+
+{-| Automatically determines a name for the created test (use this if you're lazy). -}
+defaultTest : Assertion -> Test
+defaultTest a =
+    let name = case a of
+                 AssertTrue _ -> "True"
+                 AssertFalse _ -> "False"
+                 AssertEqual _ a b    -> a ++ " == " ++ b
+                 AssertNotEqual _ a b -> a ++ " /= " ++ b
+    in test name a
+
+{-| Convert a list of `Test`s to a `Suite`. Test suites are used to group tests into
+logical units, simplifying the management and running of many tests. The `String` is the
+name of the `Suite`.  -}
+suite : String -> List Test -> Test
+suite = Suite

--- a/test/vendor/elm-test/LICENSE
+++ b/test/vendor/elm-test/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Alex Neslusan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
- Now provides (~) and (<~) which were removed from `Signal` in 0.16.
- New internal unsafeFromJust to fix 0.16 incomplete match errors.
- Temporarily use locally modified copy of elm-test for testing.
