### PR TITLE
Update for changes in Elm 0.16-alpha (without local Elm-Test)

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
         "Signal.Fun"
     ],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/src/Signal/Discrete.elm
+++ b/src/Signal/Discrete.elm
@@ -14,7 +14,7 @@ value, but only when it updates. A prime example is `Mouse.clicks`.
 @docs folde
 -}
 
-import Signal exposing ((<~), (~), Signal)
+import Signal exposing (Signal)
 
 {-| At some point in the future Elm will probably support something like
 this:

--- a/src/Signal/Fun.elm
+++ b/src/Signal/Fun.elm
@@ -13,7 +13,7 @@ careful.
 @docs scan, premap, postmap, bimap
 -}
 
-import Signal exposing (Signal, (<~), (~))
+import Signal exposing (Signal)
 
 {-| Just a shorthand for signals of functions
 -}

--- a/src/Signal/Stream.elm
+++ b/src/Signal/Stream.elm
@@ -27,8 +27,8 @@ events to your application logic.
 @docs toSignal, fromSignal
 -}
 
-import Signal exposing ((<~))
-import Signal.Extra as SignalE exposing ((~>))
+import Signal exposing (Signal)
+import Signal.Extra as SignalE exposing ((~>), (<~))
 import Signal.Time as SignalT exposing (Time)
 import Maybe exposing (Maybe(..))
 import Debug

--- a/src/Signal/Time.elm
+++ b/src/Signal/Time.elm
@@ -22,8 +22,8 @@ Some functions from the `Time` module that fit in.
 @docs Time, since, delay, timestamp
 -}
 
-import Signal exposing (Signal, (<~), (~))
-import Signal.Extra exposing ((~>))
+import Signal exposing (Signal)
+import Signal.Extra exposing ((~>), (~), (<~))
 import Signal.Discrete as Discrete
 import Time
 

--- a/test/Signal/ExtraTest.elm
+++ b/test/Signal/ExtraTest.elm
@@ -1,8 +1,8 @@
 module Signal.ExtraTest where
 
-import Signal exposing (Mailbox, mailbox, send, foldp, sampleOn, (~), (<~))
+import Signal exposing (Mailbox, mailbox, send, foldp, sampleOn)
 import Task exposing (Task, sequence, andThen)
-import Signal.Extra exposing (passiveMap2, withPassive, mapMany, andMap, deltas)
+import Signal.Extra exposing (passiveMap2, withPassive, mapMany, andMap, deltas, (~), (<~))
 import ElmTest.Test exposing (..)
 import ElmTest.Assertion exposing (..)
 import Native.ApanatshkaSignalExtra

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -12,7 +12,7 @@
     "native-modules": true,
     "dependencies": {
         "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "deadfoxygrandpa/Elm-Test": "1.0.4 <= v < 2.0.0"
+        "avh4/elm-test": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
So, this replaces #23 and fixes #22.
- Now provides `(~)` and `(<~)`, which were removed from `Signal` in 0.16.
- New internal `unsafeFromJust` to fix 0.16 incomplete match errors.

Note that this is not backwards-compatible with Elm 0.15, for reasons
discussed here:

https://github.com/Apanatshka/elm-signal-extra/pull/23#issuecomment-146927329
