### PR TITLE
Switch back to deadfoxygrandpa/elm-test, now updated for Elm 0.16.

### DIFF
--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -12,7 +12,7 @@
     "native-modules": true,
     "dependencies": {
         "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "avh4/elm-test": "1.0.0 <= v < 2.0.0"
+        "deadfoxygrandpa/elm-test": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
I had switched the testing over to avh4/elm-test, but now deadfoxygrandpa/elm-test has been updated for Elm 0.16, and avh4/elm-test is deprecated. So, we may as well switch back.
